### PR TITLE
TVI-2942 license update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 
 For the latest release info, see here:
-https://github.com/appneta/ruby-traceview/releases
+https://github.com/tracelytics/ruby-traceview/releases
 
 Dates in this file are in the format MM/DD/YYYY.
 

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -29,5 +29,4 @@ Name | Description | Default
 
 `TraceView::Config` is a nested hash used by the traceview gem to store preferences and switches.
 
-See [this Rails generator template file](https://github.com/appneta/oboe-ruby/blob/master/lib/rails/generators/traceview/templates/traceview_initializer.rb) for documentation on all of the supported values.
-
+See [this Rails generator template file](https://github.com/tracelytics/oboe-ruby/blob/master/lib/rails/generators/traceview/templates/traceview_initializer.rb) for documentation on all of the supported values.

--- a/LICENSE
+++ b/LICENSE
@@ -1,199 +1,193 @@
-AppNeta Open License, Version 1.0
-
-AppNeta Open License
-Version 1.0, April, 2013
-
-http://www.appneta.com/appneta-license
+Librato Open License
+Version 1.0, October, 2016
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 1. Definitions.
 
-"License" shall mean the terms and conditions for use, reproduction, and 
+"License" shall mean the terms and conditions for use, reproduction, and
 distribution as defined by Sections 1 through 11 of this document.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright 
-owner that is granting the License.  Licensor can include AppNeta as an 
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.  Licensor can include Librato as an
 original contributor to the Work as defined below.
 
-"Legal Entity" shall mean the union of the acting entity and all other entities 
-that control, are controlled by, or are under common control with that entity. 
-For the purposes of this definition, "control" means (i) the power, direct or 
-indirect, to cause the direction or management of such entity, whether by 
-contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the 
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
 outstanding shares, or (iii) beneficial ownership of such entity.
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising 
+"You" (or "Your") shall mean an individual or Legal Entity exercising
 permissions granted by this License.
 
-"Source" form shall mean the preferred form for making modifications, including 
-but not limited to software source code, documentation source, and 
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and
 configuration files.
 
-"Object" form shall mean any form resulting from mechanical transformation or 
-translation of a Source form, including but not limited to compiled object 
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
 code, generated documentation, and conversions to other media types.
 
-"Work" shall mean the work of authorship, whether in Source or Object form, 
-made available under the License, as indicated by a copyright notice that is 
-included in or attached to the work (an example is provided in the Appendix 
-below).
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work.
 
-"Derivative Works" shall mean any work, whether in Source or Object form, that 
-is based on (or derived from) the Work and for which the editorial revisions, 
-annotations, elaborations, or other modifications represent, as a whole, an 
-original work of authorship. For the purposes of this License, Derivative Works 
-shall not include works that remain separable from, or merely link (or bind by 
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
 name) to the interfaces of, the Work and Derivative Works thereof.
 
-"Contribution" shall mean any work of authorship, including the original 
-version of the Work and any modifications or additions to that Work or 
-Derivative Works thereof, that is intentionally submitted to Licensor for 
-inclusion in the Work by the copyright owner or by an individual or Legal 
-Entity authorized to submit on behalf of the copyright owner. For the purposes 
-of this definition, "submitted" means any form of electronic, verbal, or 
-written communication sent to the Licensor or its representatives, including 
-but not limited to communication on electronic mailing lists, source code 
-control systems, and issue tracking systems that are managed by, or on behalf 
-of, the Licensor for the purpose of discussing and improving the Work, but 
-excluding communication that is conspicuously marked or otherwise designated in 
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
 writing by the copyright owner as "Not a Contribution."
 
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf 
-of whom a Contribution has been received by Licensor and subsequently 
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
 incorporated within the Work.
 
 2. Grant of Copyright License.
 
-Subject to the terms and conditions of this License, each Contributor hereby 
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, 
-irrevocable copyright license to reproduce, prepare Derivative Works of, 
-publicly display, publicly perform, sublicense, and distribute the Work and 
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and
 such Derivative Works in Source or Object form.
 
 3. Grant of Patent License.
 
-Subject to the terms and conditions of this License, each Contributor hereby 
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, 
-irrevocable (except as stated in this section) patent license to make, have 
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where 
-such license applies only to those patent claims licensable by such Contributor 
-that are necessarily infringed by their Contribution(s) alone or by combination 
-of their Contribution(s) with the Work to which such Contribution(s) was 
-submitted. If You institute patent litigation against any entity (including a 
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a 
-Contribution incorporated within the Work constitutes direct or contributory 
-patent infringement, then any patent licenses granted to You under this License 
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
 for that Work shall terminate as of the date such litigation is filed.
 
-Each time You convey a covered Work, the recipient automatically receives a 
-license from the original Licensor(s), to run, modify and propagate that work, 
-subject to this License. You are not responsible for enforcing compliance by 
+Each time You convey a covered Work, the recipient automatically receives a
+license from the original Licensor(s), to run, modify and propagate that work,
+subject to this License. You are not responsible for enforcing compliance by
 third parties with this License.
 
-You may not impose any further restrictions on the exercise of the rights 
-granted or affirmed under this License. For example, you may not impose a 
-license fee, royalty, or other charge for exercise of rights granted under this 
-License, and you may not initiate litigation (including a cross-claim or 
-counterclaim in a lawsuit) alleging that any patent claim is infringed by 
-making, using, selling, offering for sale, or importing the Work or any portion 
+You may not impose any further restrictions on the exercise of the rights
+granted or affirmed under this License. For example, you may not impose a
+license fee, royalty, or other charge for exercise of rights granted under this
+License, and you may not initiate litigation (including a cross-claim or
+counterclaim in a lawsuit) alleging that any patent claim is infringed by
+making, using, selling, offering for sale, or importing the Work or any portion
 of it.
 
 4. Redistribution.
 
-You may reproduce and distribute copies of the Work or Derivative Works thereof 
-in any medium, with or without modifications, and in Source or Object form, 
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
 provided that You meet the following conditions:
 
-  1. You must give any other recipients of the Work or Derivative Works a copy 
+  1. You must give any other recipients of the Work or Derivative Works a copy
 of this License; and
-  2. You must cause any modified files to carry prominent notices stating that 
+  2. You must cause any modified files to carry prominent notices stating that
 You changed the files; and
-  3. You must retain, in the Source form of any Derivative Works that You 
-distribute, all copyright, patent, trademark, and attribution notices from the 
-Source form of the Work, excluding those notices that do not pertain to any 
+  3. You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
 part of the Derivative Works; and
-  4. If the Work includes a "NOTICE" text file as part of its distribution, 
-then any Derivative Works that You distribute must include a readable copy of 
-the attribution notices contained within such NOTICE file, excluding those 
-notices that do not pertain to any part of the Derivative Works, in at least 
-one of the following places: within a NOTICE text file distributed as part of 
-the Derivative Works; within the Source form or documentation, if provided 
-along with the Derivative Works; or, within a display generated by the 
-Derivative Works, if and wherever such third-party notices normally appear. The 
-contents of the NOTICE file are for informational purposes only and do not 
-modify the License. You may add Your own attribution notices within Derivative 
-Works that You distribute, alongside or as an addendum to the NOTICE text from 
-the Work, provided that such additional attribution notices cannot be construed 
+  4. If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear. The
+contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative
+Works that You distribute, alongside or as an addendum to the NOTICE text from
+the Work, provided that such additional attribution notices cannot be construed
 as modifying the License.
 
-You may add Your own copyright statement to Your modifications and may provide 
-additional or different license terms and conditions for use, reproduction, or 
-distribution of Your modifications, or for any such Derivative Works as a 
-whole, provided Your use, reproduction, and distribution of the Work otherwise 
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a
+whole, provided Your use, reproduction, and distribution of the Work otherwise
 complies with the conditions stated in this License.
 
 5. Submission of Contributions.
 
-Unless You explicitly state otherwise, any Contribution intentionally submitted 
-for inclusion in the Work by You to the Licensor shall be under the terms and 
-conditions of this License, without any additional terms or conditions. 
-Notwithstanding the above, nothing herein shall supersede or modify the terms 
-of any separate license agreement you may have executed with Licensor regarding 
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms
+of any separate license agreement you may have executed with Licensor regarding
 such Contributions.
 
 6. Trademarks.
 
-This License does not grant permission to use the trade names, trademarks, 
-service marks, or product names of the Licensor, except as required for 
-reasonable and customary use in describing the origin of the Work and 
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
 reproducing the content of the NOTICE file.
 
 7. Disclaimer of Warranty.
 
-Unless required by applicable law or agreed to in writing, Licensor provides 
-the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, 
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, 
-including, without limitation, any warranties or conditions of TITLE, 
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are 
-solely responsible for determining the appropriateness of using or 
-redistributing the Work and assume any risks associated with Your exercise of 
+Unless required by applicable law or agreed to in writing, Licensor provides
+the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
 permissions under this License.
 
 8. Limitation of Liability.
 
-In no event and under no legal theory, whether in tort (including negligence), 
-contract, or otherwise, unless required by applicable law (such as deliberate 
-and grossly negligent acts) or agreed to in writing, shall any Contributor be 
-liable to You for damages, including any direct, indirect, special, incidental, 
-or consequential damages of any character arising as a result of this License 
-or out of the use or inability to use the Work (including but not limited to 
-damages for loss of goodwill, work stoppage, computer failure or malfunction, 
-or any and all other commercial damages or losses), even if such Contributor 
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License
+or out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction,
+or any and all other commercial damages or losses), even if such Contributor
 has been advised of the possibility of such damages.
 
 9. Accepting Warranty or Additional Liability.
 
-While redistributing the Work or Derivative Works thereof, You may choose to 
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or 
-other liability obligations and/or rights consistent with this License. 
-However, in accepting such obligations, You may act only on Your own behalf and 
-on Your sole responsibility, not on behalf of any other Contributor, and only 
-if You agree to indemnify, defend, and hold each Contributor harmless for any 
-liability incurred by, or claims asserted against, such Contributor by reason 
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License.
+However, in accepting such obligations, You may act only on Your own behalf and
+on Your sole responsibility, not on behalf of any other Contributor, and only
+if You agree to indemnify, defend, and hold each Contributor harmless for any
+liability incurred by, or claims asserted against, such Contributor by reason
 of your accepting any such warranty or additional liability.
 
 10. Noncompetition
 
-You may install and execute the Work only in conjunction with the direct use of 
-AppNeta software.  This Work, any file or any derivative thereof shall not be 
-used in conjunction with any product that competes with any AppNeta software.
+You may install and execute the Work only in conjunction with the direct use of
+Librato software.  This Work, any file or any derivative thereof shall not be
+used in conjunction with any product that competes with any Librato software.
 
 11. Termination
 
-The License stated above is automatically terminated and revoked if you exceed 
-its scope or violate any of the terms of this License or any related License or 
+The License stated above is automatically terminated and revoked if you exceed
+its scope or violate any of the terms of this License or any related License or
 notice.
 
 END OF TERMS AND CONDITIONS
-

--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Welcome to the TraceView Ruby Gem
 
-The traceview gem provides AppNeta [TraceView](http://www.appneta.com/application-performance-management/) performance instrumentation for Ruby.
+The traceview gem provides [TraceView](https://traceview.solarwinds.com/) performance instrumentation for Ruby.
 
-![Ruby TraceView](https://s3.amazonaws.com/pglombardo/oboe-ruby-header.png)
+![Ruby TraceView](http://docs.traceview.solarwinds.com/images/ruby_readme/oboe-ruby-header.png)
 
-It has the ability to report performance metrics on an array of libraries, databases and frameworks such as Rails, Mongo, Memcache, ActiveRecord, Cassandra, Rack, Resque [and more](https://docs.appneta.com/ruby-instrumentation-supported-components)
+It has the ability to report performance metrics on an array of libraries, databases and frameworks such as Rails, Mongo, Memcache, ActiveRecord, Cassandra, Rack, Resque [and more](http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#ruby-support-matrix).
 
-It requires a [TraceView](http://www.appneta.com/products/traceview/) account to view metrics.  Get yours, [it's free](http://www.appneta.com/products/traceview-free-account/).
+It requires a [TraceView](https://traceview.solarwinds.com/) account to view metrics.  Get yours, [it's free](https://traceview.solarwinds.com/TraceView/Signup).
 
 [![Gem Version](https://badge.fury.io/rb/traceview.png)](https://badge.fury.io/rb/traceview)
-[![Build Status](https://travis-ci.org/appneta/ruby-traceview.png?branch=master)](https://travis-ci.org/appneta/ruby-traceview)
-[![Code Climate](https://codeclimate.com/github/appneta/ruby-traceview.png)](https://codeclimate.com/github/appneta/ruby-traceview)
+[![Build Status](https://travis-ci.org/tracelytics/ruby-traceview.png?branch=master)](https://travis-ci.org/tracelytics/ruby-traceview)
+[![Code Climate](https://codeclimate.com/github/tracelytics/ruby-traceview.png)](https://codeclimate.com/github/tracelytics/ruby-traceview)
 
-_Note: The repository name has been changed to ruby-traceview.  Please update your github remotes with `git remote set-url origin git@github.com:appneta/ruby-traceview.git`._
+_Note: The repository name has been changed to ruby-traceview.  Please update your github remotes with `git remote set-url origin git@github.com:tracelytics/ruby-traceview.git`._
 
 # Installation
 
-_Before installing the gem below, make sure that you have the [base packages](http://docs.appneta.com/installation-overview#1-install-base-packages) installed on your host first._
+_Before installing the gem below, make sure that you have the [base packages](http://docs.traceview.solarwinds.com/TraceView/install-instrumentation.html#install-base-packages) installed on your host first._
 
 The traceview gem is [available on Rubygems](https://rubygems.org/gems/traceview) and can be installed with:
 
@@ -34,7 +34,7 @@ gem 'traceview'
 
 ## Rails
 
-![Ruby on Rails](http://www.appneta.com/images/logos/frameworks/rails.png)
+![Ruby on Rails](http://docs.traceview.solarwinds.com/images/ruby_readme/rails.png)
 
 No special steps are needed to instrument Ruby on Rails.  Once part of the bundle, the traceview gem will automatically detect Rails and instrument on stack initialization.
 
@@ -42,7 +42,7 @@ No special steps are needed to instrument Ruby on Rails.  Once part of the bundl
 
 ### The Install Generator
 
-The traceview gem provides a Rails generator used to seed an initializer where you can configure and control `tracing_mode` and [other options](https://docs.appneta.com/configuring-ruby-instrumentation)
+The traceview gem provides a Rails generator used to seed an initializer where you can configure and control `tracing_mode` and [other options](http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#configuring-instrumentation).
 
 To run the install generator run:
 
@@ -54,7 +54,7 @@ After the prompts, this will create an initializer: `config/initializers/tracevi
 
 ## Sinatra
 
-![Sinatra](http://www.appneta.com/images/logos/frameworks/sinatra.png)
+![Sinatra](http://docs.traceview.solarwinds.com/images/ruby_readme/sinatra.png)
 
 You can instrument your Sinatra application by adding the following code to your `config.ru` Rackup file:
 
@@ -79,7 +79,7 @@ With this, the traceview gem will automatically detect Sinatra on boot and instr
 
 ## Padrino
 
-![Padrino](http://www.appneta.com/images/logos/frameworks/padrino.png)
+![Padrino](http://docs.traceview.solarwinds.com/images/ruby_readme/padrino.png)
 
 As long as the traceview gem is in your `Gemfile` (inserted after the `gem 'padrino'` directive) and you are calling `Bundler.require`, the traceview gem will automatically instrument Padrino applications.
 
@@ -98,7 +98,7 @@ end
 
 ## Grape
 
-![Grape](http://www.appneta.com/images/logos/frameworks/grape.png)
+![Grape](http://docs.traceview.solarwinds.com/images/ruby_readme/grape.png)
 
 You can instrument your Grape application by adding the following code to your `config.ru` Rackup file:
 
@@ -106,13 +106,13 @@ You can instrument your Grape application by adding the following code to your `
     # If you're not using Bundler.require.  Make sure this is done
     # after the Grape require directive.
     require 'traceview'
-    
+
     # When traces should be initiated for incoming requests. Valid options are
     # "always", "through" (when the request is initiated with a tracing header
     # from upstream) and "never". You must set this directive to "always" in
     # order to initiate tracing.
     TraceView::Config[:tracing_mode] = 'through'
-    
+
     ...
 
     class App < Grape::API
@@ -146,7 +146,7 @@ Once inside of the `TraceView::API.start_trace` block, performance metrics will 
 
 ## Other
 
-You can send deploy notifications to TraceView and have the events show up on your dashboard.  See: [Capistrano Deploy Notifications with tlog](https://docs.appneta.com/capistrano-deploy-notifications-tlog)
+You can send deploy notifications to TraceView and have the events show up on your dashboard.  See: [Capistrano Deploy Notifications with tlog](http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#report-deploy-notifications)
 
 # Custom Tracing
 
@@ -191,11 +191,11 @@ If, for example, you wanted to see the performance for the `Array::sort`, you co
 TraceView::API.profile_method(Array, :sort)
 ```
 
-For full documentation, options and reporting custom KVs, see our documentation on [method profiling](http://docs.appneta.com/ruby#profiling-ruby-methods).
+For full documentation, options and reporting custom KVs, see our documentation on [method profiling](http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#ruby-function-profiling).
 
 # Support
 
-If you find a bug or would like to request an enhancement, feel free to file an issue.  For all other support requests, see our [support portal](https://tickets.appneta.com) or on IRC @ #appneta on [Freenode](http://freenode.net/).
+If you find a bug or would like to request an enhancement, feel free to file an issue.  For all other support requests, see our [support portal](https://tracelytics.freshdesk.com).
 
 # Contributing
 
@@ -205,13 +205,9 @@ We welcome you to send us PRs.  We also humbly request that any new instrumentat
 
 ## Developer Resources
 
-We at AppNeta have made a large effort to expose as much technical information as possible to assist developers wishing to contribute to the traceview gem.  Below are the three major sources for information and help for developers:
+We have made a large effort to expose as much technical information as possible to assist developers wishing to contribute to the traceview gem.  Below is a good source for information and help for developers:
 
-* The [TraceView blog](http://www.appneta.com/blog) has a constant stream of great technical articles.  (See [A Gentle X-Trace Introduction](http://www.appneta.com/blog/x-trace-introduction/) for details on the basic methodology that TraceView uses to gather structured performance data across hosts and stacks.)
-
-* The [TraceView Documentation Portal](https://docs.appneta.com/ruby) has a large collection of technical articles or, if needed, you can [submit a support request](https://tickets.appneta.com) directly to the team.
-
-* You can also reach the TraceView team on our IRC channel #appneta on freenode.
+* The [TraceView Knowledge Base](http://docs.traceview.solarwinds.com/) has a large collection of technical articles or, if needed, you can submit a support request directly to the team.
 
 If you have any questions or ideas, don't hesitate to contact us anytime.
 
@@ -297,8 +293,6 @@ Third, in our wrapper method, we capture the arguments passed in, collect the op
 
 The `TraceView::API.trace` method calls Dalli's native operation and reports the timing metrics and your custom `report_kvs` up to TraceView servers to be shown on the user's dashboard.
 
-That is a very quick example of a simple instrumentation implementation.  If you have any questions, visit us on IRC in #appneta on Freenode.
-
 Some other tips and guidelines:
 
 * You can point your Gemfile directly at your cloned traceview gem source by using `gem 'traceview', :path => '/path/to/ruby-traceview'`
@@ -317,7 +311,7 @@ Some other tips and guidelines:
 
 ## Compiling the C extension
 
-The traceview gem utilizes a C extension to interface with the system `liboboe.so` library.  This system library is installed with the TraceView host packages (tracelyzer, liboboe0, liboboe-dev) and is used to report [host](http://www.appneta.com/blog/app-host-metrics/) and performance metrics from multiple sources (Ruby, Apache, Python etc.) back to TraceView servers.
+The traceview gem utilizes a C extension to interface with the system `liboboe.so` library.  This system library is installed with the TraceView host packages (tracelyzer, liboboe0, liboboe-dev) and is used to report host and performance metrics from multiple sources (Ruby, Apache, Python etc.) back to TraceView servers.
 
 C extensions are usually built on `gem install` but when working out of a local git repository, it's required that you manually build this C extension for the gem to function.
 
@@ -333,11 +327,11 @@ Note: Make sure you have the development package `liboboe0-dev` installed before
 
 ```bash
 >>$ dpkg -l | grep liboboe
-ii  liboboe-dev  1.2.1-trusty1  AppNeta TraceView common library -- development files
-ii  liboboe0     1.2.1-trusty1  AppNeta Traceview common library
+ii  liboboe-dev  1.2.1-trusty1  TraceView common library -- development files
+ii  liboboe0     1.2.1-trusty1  Traceview common library
 ```
 
-See [Installing Base Packages on Debian and Ubuntu](https://docs.appneta.com/installation-overview) in the Knowledge Base for details.  Our hacker extraordinaire [Rob Salmond](https://github.com/rsalmond) from the support team has even gotten these packages to [run on Gentoo](http://www.appneta.com/blog/unsupported-doesnt-work/)!
+See [Installing Base Packages on Debian and Ubuntu](http://docs.traceview.solarwinds.com/TraceView/install-instrumentation.html#debian-and-ubuntu) in the Knowledge Base for details.
 
 To see the code related to the C extension, take a look at `ext/oboe_metal/extconf.rb` for details.
 
@@ -345,7 +339,7 @@ You can read more about Ruby gems with C extensions in the [Rubygems Guides](htt
 
 ## Running the Tests
 
-![TraceView Ruby Tests](https://s3.amazonaws.com/appneta/tv_ruby_tests.png)
+![TraceView Ruby Tests](http://docs.traceview.solarwinds.com/images/ruby_readme/tv_ruby_tests.png)
 
 The tests bundled with the gem are implemented using [Minitest](https://github.com/seattlerb/minitest).  The tests are currently used to validate the sanity of the traces generated and basic gem functionality.
 
@@ -369,7 +363,6 @@ We humbly request that any submitted instrumentation is delivered with correspon
 
 # License
 
-Copyright (c) 2014 Appneta
+Copyright (c) 2016 SolarWinds, LLC
 
-Released under the [AppNeta Open License](http://www.appneta.com/appneta-license), Version 1.0
-
+Released under the [Librato Open License](http://docs.traceview.solarwinds.com/Instrumentation/librato-open-license.html)

--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ task :compile do
     else
       Dir.chdir pwd
       puts '!! Extension failed to build (see above).  Are the base TraceView packages installed?'
-      puts '!! See https://docs.appneta.com/install-instrumentation'
+      puts '!! See http://docs.traceview.solarwinds.com/TraceView/install-instrumentation.html'
     end
   else
     puts '== Nothing to do under JRuby.'

--- a/examples/DNT.md
+++ b/examples/DNT.md
@@ -32,4 +32,4 @@ Since this pattern is used with the standard Ruby Regexp class, you can
 use any Regexp supported pattern.  See the documentation on Ruby Regexp
 [here](https://www.omniref.com/ruby/2.2.0/symbols/Regexp?d=380181456&n=0#doc_uncollapsed=true&d=380181456&n=0)
 or you can also view the oboe gem [source code documentation for this
-feature](https://github.com/appneta/oboe-ruby/blob/master/lib/oboe/config.rb#L74).
+feature](https://github.com/tracelytics/ruby-traceview/blob/master/lib/traceview/config.rb#L129).

--- a/examples/tracing_async_threads.rb
+++ b/examples/tracing_async_threads.rb
@@ -120,6 +120,5 @@ end
 #      end
 #    end
 #
-# If anything isn't clear, please don't hesitate to reach us at support (traceviewsupport@appneta.com)
-# or on IRC #appneta @ freenode.
+# If anything isn't clear, please don't hesitate to reach us at support (traceviewsupport@solarwinds.com).
 #

--- a/ext/oboe_metal/extconf.rb
+++ b/ext/oboe_metal/extconf.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'mkmf'

--- a/ext/oboe_metal/tests/test.rb
+++ b/ext/oboe_metal/tests/test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'oboe'

--- a/gemfiles/delayed_job.gemfile
+++ b/gemfiles/delayed_job.gemfile
@@ -21,7 +21,12 @@ if defined?(JRUBY_VERSION)
   gem 'jdbc-postgresql'
 else
   gem 'sinatra'
-  gem 'pg'
+  # pg 0.19 and above require ruby 2.0
+  if RUBY_VERSION < '2.0'
+    gem 'pg', '< 0.19'
+  else
+    gem 'pg'
+  end
   gem "delayed_job_active_record"
 end
 

--- a/gemfiles/libraries.gemfile
+++ b/gemfiles/libraries.gemfile
@@ -80,6 +80,8 @@ else
   gem 'mysql2'
   if RUBY_VERSION < '1.9.3'
     gem 'pg', '0.17.1'
+  elsif RUBY_VERSION < '2.0'
+    gem 'pg', '0.18.4'
   else
     gem 'pg'
   end

--- a/gemfiles/rails40.gemfile
+++ b/gemfiles/rails40.gemfile
@@ -16,7 +16,7 @@ if defined?(JRUBY_VERSION)
   gem 'jdbc-postgresql'
 else
   gem 'sinatra'
-  gem 'pg'
+  gem 'pg', '< 0.19'
   gem 'mysql'
   gem 'mysql2', '< 0.4.0'
 end

--- a/gemfiles/rails41.gemfile
+++ b/gemfiles/rails41.gemfile
@@ -16,7 +16,7 @@ if defined?(JRUBY_VERSION)
   gem 'jdbc-postgresql'
 else
   gem 'sinatra'
-  gem 'pg'
+  gem 'pg', '< 0.19'
   gem 'mysql'
   gem 'mysql2'
 end

--- a/gemfiles/rails42.gemfile
+++ b/gemfiles/rails42.gemfile
@@ -21,7 +21,7 @@ if defined?(JRUBY_VERSION)
   gem 'jdbc-postgresql'
 else
   gem 'sinatra'
-  gem 'pg'
+  gem 'pg', '< 0.19'
   gem 'mysql'
   gem 'mysql2'
 end

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'traceview'

--- a/lib/joboe_metal.rb
+++ b/lib/joboe_metal.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module Oboe_metal

--- a/lib/joboe_metal.rb
+++ b/lib/joboe_metal.rb
@@ -202,7 +202,7 @@ case Java::ComTracelyticsAgent::Agent.getStatus
     $stderr.puts '=============================================================='
     $stderr.puts 'TraceView Java Agent not initialized properly.'
     $stderr.puts 'Possibly misconfigured?  Going into no-op mode.'
-    $stderr.puts 'https://docs.appneta.com/installing-jruby-instrumentation'
+    $stderr.puts 'http://docs.traceview.solarwinds.com/Instrumentation/other-instrumentation-modules.html#jruby'
     $stderr.puts '=============================================================='
 
   when Java::ComTracelyticsAgent::Agent::AgentStatus::UNINITIALIZED
@@ -210,7 +210,7 @@ case Java::ComTracelyticsAgent::Agent.getStatus
     $stderr.puts '=============================================================='
     $stderr.puts 'TraceView Java Agent not loaded. Going into no-op mode.'
     $stderr.puts 'To preload the TraceView java agent see:'
-    $stderr.puts 'https://docs.appneta.com/installing-jruby-instrumentation'
+    $stderr.puts 'http://docs.traceview.solarwinds.com/Instrumentation/other-instrumentation-modules.html#jruby'
     $stderr.puts '=============================================================='
 
   else

--- a/lib/oboe.rb
+++ b/lib/oboe.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # This module is provided for backward compatibility.

--- a/lib/oboe_metal.rb
+++ b/lib/oboe_metal.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'thread'

--- a/lib/rails/generators/traceview/install_generator.rb
+++ b/lib/rails/generators/traceview/install_generator.rb
@@ -48,10 +48,10 @@ module TraceView
         say "-------------------"
         say ""
         say "TraceView Installation Overview:"
-        say "https://docs.appneta.com/installation-overview"
+        say "http://docs.traceview.solarwinds.com/TraceView/install-instrumentation.html"
         say ""
         say "More information on instrumenting Ruby applications can be found here:"
-        say "https://docs.appneta.com/installing-ruby-instrumentation"
+        say "http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#installing-ruby-instrumentation"
       end
 
       def print_body

--- a/lib/rails/generators/traceview/install_generator.rb
+++ b/lib/rails/generators/traceview/install_generator.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/rails/generators/traceview/templates/traceview_initializer.rb
+++ b/lib/rails/generators/traceview/templates/traceview_initializer.rb
@@ -1,8 +1,8 @@
-# AppNeta TraceView Initializer (for the traceview gem)
-# http://www.appneta.com/products/traceview/
+# TraceView Initializer (for the traceview gem)
+# https://traceview.solarwinds.com/
 #
 # More information on instrumenting Ruby applications can be found here:
-# https://support.appneta.com/cloud/installing-ruby-instrumentation
+# http://docs.traceview.solarwinds.com/Instrumentation/ruby.html#installing-ruby-instrumentation
 
 if defined?(TraceView::Config)
   # Tracing Mode determines when traces should be initiated for incoming requests.  Valid
@@ -99,7 +99,7 @@ if defined?(TraceView::Config)
   #
   # Alternatively, if you would like to install the separate
   # libcurl instrumentation, see here:
-  # http://docs.appneta.com/installing-libcurl-instrumentation
+  # http://docs.traceview.solarwinds.com/Instrumentation/other-instrumentation-modules.html#libcurl
   #
   # TraceView::Config[:curb][:cross_host] = false
   #

--- a/lib/traceview.rb
+++ b/lib/traceview.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # Backward compatibility for supported environment variables

--- a/lib/traceview/api.rb
+++ b/lib/traceview/api.rb
@@ -4,7 +4,7 @@
 module TraceView
   ##
   # This module implements the TraceView tracing API.
-  # See: https://github.com/appneta/oboe-ruby#the-tracing-api
+  # See: https://github.com/tracelytics/ruby-traceview#the-tracing-api
   # and/or: http://rdoc.info/gems/traceview/TraceView/API/Tracing
   module API
     def self.extend_with_tracing

--- a/lib/traceview/api.rb
+++ b/lib/traceview/api.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/api/layerinit.rb
+++ b/lib/traceview/api/layerinit.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/api/logging.rb
+++ b/lib/traceview/api/logging.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # Make sure Set is loaded if possible.

--- a/lib/traceview/api/memcache.rb
+++ b/lib/traceview/api/memcache.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/api/profiling.rb
+++ b/lib/traceview/api/profiling.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/api/tracing.rb
+++ b/lib/traceview/api/tracing.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/api/util.rb
+++ b/lib/traceview/api/util.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'pp'

--- a/lib/traceview/base.rb
+++ b/lib/traceview/base.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # Constants from liboboe

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/config.rb
+++ b/lib/traceview/config.rb
@@ -174,7 +174,7 @@ module TraceView
       #
       # Alternatively, if you would like to install the separate
       # libcurl instrumentation, see here:
-      # http://docs.appneta.com/installing-libcurl-instrumentation
+      # http://docs.traceview.solarwinds.com/Instrumentation/other-instrumentation-modules.html#libcurl
       #
       @@config[:curb][:cross_host] = false
 

--- a/lib/traceview/frameworks/grape.rb
+++ b/lib/traceview/frameworks/grape.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/padrino.rb
+++ b/lib/traceview/frameworks/padrino.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/padrino/templates.rb
+++ b/lib/traceview/frameworks/padrino/templates.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails.rb
+++ b/lib/traceview/frameworks/rails.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller2.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller2.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller3.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller3.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller4.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller4.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller5.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller5.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_controller_api.rb
+++ b/lib/traceview/frameworks/rails/inst/action_controller_api.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/action_view.rb
+++ b/lib/traceview/frameworks/rails/inst/action_view.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if defined?(ActionView::Base) && TraceView::Config[:action_view][:enabled]

--- a/lib/traceview/frameworks/rails/inst/action_view_2x.rb
+++ b/lib/traceview/frameworks/rails/inst/action_view_2x.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if defined?(ActionView::Base) && TraceView::Config[:action_view][:enabled]

--- a/lib/traceview/frameworks/rails/inst/action_view_30.rb
+++ b/lib/traceview/frameworks/rails/inst/action_view_30.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if defined?(ActionView::Base) && TraceView::Config[:action_view][:enabled]

--- a/lib/traceview/frameworks/rails/inst/active_record.rb
+++ b/lib/traceview/frameworks/rails/inst/active_record.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'traceview/frameworks/rails/inst/connection_adapters/mysql'

--- a/lib/traceview/frameworks/rails/inst/connection_adapters/mysql.rb
+++ b/lib/traceview/frameworks/rails/inst/connection_adapters/mysql.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/connection_adapters/mysql2.rb
+++ b/lib/traceview/frameworks/rails/inst/connection_adapters/mysql2.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/connection_adapters/postgresql.rb
+++ b/lib/traceview/frameworks/rails/inst/connection_adapters/postgresql.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/connection_adapters/utils.rb
+++ b/lib/traceview/frameworks/rails/inst/connection_adapters/utils.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/rails/inst/connection_adapters/utils5x.rb
+++ b/lib/traceview/frameworks/rails/inst/connection_adapters/utils5x.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/sinatra.rb
+++ b/lib/traceview/frameworks/sinatra.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/frameworks/sinatra/templates.rb
+++ b/lib/traceview/frameworks/sinatra/templates.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/bunny-client.rb
+++ b/lib/traceview/inst/bunny-client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/bunny-consumer.rb
+++ b/lib/traceview/inst/bunny-consumer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/curb.rb
+++ b/lib/traceview/inst/curb.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/dalli.rb
+++ b/lib/traceview/inst/dalli.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/delayed_job.rb
+++ b/lib/traceview/inst/delayed_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if defined?(::Delayed)

--- a/lib/traceview/inst/em-http-request.rb
+++ b/lib/traceview/inst/em-http-request.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/excon.rb
+++ b/lib/traceview/inst/excon.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/faraday.rb
+++ b/lib/traceview/inst/faraday.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/http.rb
+++ b/lib/traceview/inst/http.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'net/http'

--- a/lib/traceview/inst/httpclient.rb
+++ b/lib/traceview/inst/httpclient.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/memcache.rb
+++ b/lib/traceview/inst/memcache.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/memcached.rb
+++ b/lib/traceview/inst/memcached.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/mongo.rb
+++ b/lib/traceview/inst/mongo.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'json'

--- a/lib/traceview/inst/mongo2.rb
+++ b/lib/traceview/inst/mongo2.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'json'

--- a/lib/traceview/inst/moped.rb
+++ b/lib/traceview/inst/moped.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'json'

--- a/lib/traceview/inst/rack.rb
+++ b/lib/traceview/inst/rack.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'uri'

--- a/lib/traceview/inst/redis.rb
+++ b/lib/traceview/inst/redis.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/resque.rb
+++ b/lib/traceview/inst/resque.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'socket'

--- a/lib/traceview/inst/rest-client.rb
+++ b/lib/traceview/inst/rest-client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/sequel.rb
+++ b/lib/traceview/inst/sequel.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/sidekiq-client.rb
+++ b/lib/traceview/inst/sidekiq-client.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/sidekiq-worker.rb
+++ b/lib/traceview/inst/sidekiq-worker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/twitter-cassandra.rb
+++ b/lib/traceview/inst/twitter-cassandra.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/inst/typhoeus.rb
+++ b/lib/traceview/inst/typhoeus.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/instrumentation.rb
+++ b/lib/traceview/instrumentation.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/legacy_method_profiling.rb
+++ b/lib/traceview/legacy_method_profiling.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 ##

--- a/lib/traceview/loading.rb
+++ b/lib/traceview/loading.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'digest/sha1'

--- a/lib/traceview/logger.rb
+++ b/lib/traceview/logger.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'logger'

--- a/lib/traceview/ruby.rb
+++ b/lib/traceview/ruby.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/support.rb
+++ b/lib/traceview/support.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'rbconfig'

--- a/lib/traceview/support.rb
+++ b/lib/traceview/support.rb
@@ -25,7 +25,7 @@ module TraceView
 
     TraceView.logger.warn '********************************************************'
     TraceView.logger.warn '* BEGIN TraceView Support Report'
-    TraceView.logger.warn '*   Please email the output of this report to traceviewsupport@appneta.com'
+    TraceView.logger.warn '*   Please email the output of this report to traceviewsupport@solarwinds.com'
     TraceView.logger.warn '********************************************************'
     TraceView.logger.warn "Ruby: #{RUBY_DESCRIPTION}"
     TraceView.logger.warn "$0: #{$0}"
@@ -124,10 +124,9 @@ module TraceView
 
     TraceView.logger.warn '********************************************************'
     TraceView.logger.warn '* END TraceView Support Report'
-    TraceView.logger.warn '*   Support Email: traceviewsupport@appneta.com'
-    TraceView.logger.warn '*   Support Portal: https://tickets.appneta.com'
-    TraceView.logger.warn '*   Freenode IRC: #appneta'
-    TraceView.logger.warn '*   Github: https://github.com/appneta/ruby-traceview'
+    TraceView.logger.warn '*   Support Email: traceviewsupport@solarwinds.com'
+    TraceView.logger.warn '*   Support Portal: https://tracelytics.freshdesk.com'
+    TraceView.logger.warn '*   Github: https://github.com/tracelytics/ruby-traceview'
     TraceView.logger.warn '********************************************************'
 
     TraceView.logger.level = @logger_level

--- a/lib/traceview/test.rb
+++ b/lib/traceview/test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/thread_local.rb
+++ b/lib/traceview/thread_local.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/util.rb
+++ b/lib/traceview/util.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/version.rb
+++ b/lib/traceview/version.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/lib/traceview/xtrace.rb
+++ b/lib/traceview/xtrace.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 module TraceView

--- a/test/frameworks/apps/grape_nested.rb
+++ b/test/frameworks/apps/grape_nested.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'grape'

--- a/test/frameworks/apps/grape_simple.rb
+++ b/test/frameworks/apps/grape_simple.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'grape'

--- a/test/frameworks/apps/sinatra_simple.rb
+++ b/test/frameworks/apps/sinatra_simple.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'sinatra'

--- a/test/frameworks/grape_test.rb
+++ b/test/frameworks/grape_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/frameworks/padrino_test.rb
+++ b/test/frameworks/padrino_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/frameworks/rails3x_test.rb
+++ b/test/frameworks/rails3x_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/frameworks/rails4x_test.rb
+++ b/test/frameworks/rails4x_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/frameworks/rails5x_api_test.rb
+++ b/test/frameworks/rails5x_api_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/frameworks/rails5x_test.rb
+++ b/test/frameworks/rails5x_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/frameworks/sinatra_test.rb
+++ b/test/frameworks/sinatra_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require "minitest_helper"

--- a/test/instrumentation/bunny_client_test.rb
+++ b/test/instrumentation/bunny_client_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/bunny_consumer_test.rb
+++ b/test/instrumentation/bunny_consumer_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/curb_test.rb
+++ b/test/instrumentation/curb_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if RUBY_VERSION > '1.8.7' && !defined?(JRUBY_VERSION)

--- a/test/instrumentation/dalli_test.rb
+++ b/test/instrumentation/dalli_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if RUBY_VERSION > '1.8.7'

--- a/test/instrumentation/em_http_request_test.rb
+++ b/test/instrumentation/em_http_request_test.rb
@@ -5,7 +5,7 @@ require 'minitest_helper'
 
 # Disable this test on JRuby until we can investigate
 # "SOCKET: SET COMM INACTIVITY UNIMPLEMENTED 10"
-# https://travis-ci.org/appneta/traceview-ruby/jobs/33745752
+# https://travis-ci.org/tracelytics/ruby-traceview/jobs/33745752
 if RUBY_VERSION >= '1.9' and TraceView::Config[:em_http_request][:enabled] and not defined?(JRUBY_VERSION)
 
   describe "EventMachine" do

--- a/test/instrumentation/em_http_request_test.rb
+++ b/test/instrumentation/em_http_request_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/excon_test.rb
+++ b/test/instrumentation/excon_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/faraday_test.rb
+++ b/test/instrumentation/faraday_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/http_test.rb
+++ b/test/instrumentation/http_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/httpclient_test.rb
+++ b/test/instrumentation/httpclient_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 unless defined?(JRUBY_VERSION)

--- a/test/instrumentation/memcache_test.rb
+++ b/test/instrumentation/memcache_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/memcached_test.rb
+++ b/test/instrumentation/memcached_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/mongo_v1_test.rb
+++ b/test/instrumentation/mongo_v1_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/mongo_v2_index_test.rb
+++ b/test/instrumentation/mongo_v2_index_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/mongo_v2_test.rb
+++ b/test/instrumentation/mongo_v2_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/mongo_v2_view_test.rb
+++ b/test/instrumentation/mongo_v2_view_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/moped_test.rb
+++ b/test/instrumentation/moped_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/rack_test.rb
+++ b/test/instrumentation/rack_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_hashes_test.rb
+++ b/test/instrumentation/redis_hashes_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_keys_test.rb
+++ b/test/instrumentation/redis_keys_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_lists_test.rb
+++ b/test/instrumentation/redis_lists_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_misc_test.rb
+++ b/test/instrumentation/redis_misc_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_sets_test.rb
+++ b/test/instrumentation/redis_sets_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_sortedsets_test.rb
+++ b/test/instrumentation/redis_sortedsets_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/redis_strings_test.rb
+++ b/test/instrumentation/redis_strings_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/resque_test.rb
+++ b/test/instrumentation/resque_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if RUBY_VERSION >= '1.9.3' && !defined?(JRUBY_VERSION)

--- a/test/instrumentation/rest-client_test.rb
+++ b/test/instrumentation/rest-client_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/sequel_mysql2_test.rb
+++ b/test/instrumentation/sequel_mysql2_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/sequel_mysql_test.rb
+++ b/test/instrumentation/sequel_mysql_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/sequel_pg_test.rb
+++ b/test/instrumentation/sequel_pg_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/sidekiq-client_test.rb
+++ b/test/instrumentation/sidekiq-client_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if RUBY_VERSION >= '2.0' && !defined?(JRUBY_VERSION)

--- a/test/instrumentation/sidekiq-worker_test.rb
+++ b/test/instrumentation/sidekiq-worker_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 if RUBY_VERSION >= '2.0' && !defined?(JRUBY_VERSION)

--- a/test/instrumentation/twitter-cassandra_test.rb
+++ b/test/instrumentation/twitter-cassandra_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/instrumentation/typhoeus_test.rb
+++ b/test/instrumentation/typhoeus_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/jobs/delayed_job/db_worker_job.rb
+++ b/test/jobs/delayed_job/db_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class DJDBWorkerJob

--- a/test/jobs/delayed_job/error_worker_job.rb
+++ b/test/jobs/delayed_job/error_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class DJErrorWorkerJob

--- a/test/jobs/delayed_job/remote_call_worker_job.rb
+++ b/test/jobs/delayed_job/remote_call_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class DJRemoteCallWorkerJob

--- a/test/jobs/resque/db_worker_job.rb
+++ b/test/jobs/resque/db_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class ResqueDBWorkerJob

--- a/test/jobs/resque/error_worker_job.rb
+++ b/test/jobs/resque/error_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class ResqueErrorWorkerJob

--- a/test/jobs/resque/remote_call_worker_job.rb
+++ b/test/jobs/resque/remote_call_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class ResqueRemoteCallWorkerJob

--- a/test/jobs/sidekiq/db_worker_job.rb
+++ b/test/jobs/sidekiq/db_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class DBWorkerJob

--- a/test/jobs/sidekiq/error_worker_job.rb
+++ b/test/jobs/sidekiq/error_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class ErrorWorkerJob

--- a/test/jobs/sidekiq/remote_call_worker_job.rb
+++ b/test/jobs/sidekiq/remote_call_worker_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 class RemoteCallWorkerJob

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'rubygems'

--- a/test/profiling/legacy_method_profiling_test.rb
+++ b/test/profiling/legacy_method_profiling_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/profiling/method_profiling_test.rb
+++ b/test/profiling/method_profiling_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 require 'minitest_helper'
 

--- a/test/queues/delayed_job-client_test.rb
+++ b/test/queues/delayed_job-client_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/queues/delayed_job-worker_test.rb
+++ b/test/queues/delayed_job-worker_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/reporter/reporter_test.rb
+++ b/test/reporter/reporter_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/servers/delayed_job.rb
+++ b/test/servers/delayed_job.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # This is a Rails app that launches a DelayedJob worker

--- a/test/servers/rackapp_8101.rb
+++ b/test/servers/rackapp_8101.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # This is a Rack application that is booted in a background

--- a/test/servers/rails3x_8140.rb
+++ b/test/servers/rails3x_8140.rb
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 #  This is a Rails stack that launches on a background

--- a/test/servers/rails4x_8140.rb
+++ b/test/servers/rails4x_8140.rb
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 #  This is a Rails stack that launches on a background

--- a/test/servers/rails5x_8140.rb
+++ b/test/servers/rails5x_8140.rb
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 #  This is a Rails stack that launches on a background

--- a/test/servers/rails5x_api_8150.rb
+++ b/test/servers/rails5x_api_8150.rb
@@ -1,5 +1,5 @@
 ##
-# Copyright (c) 2016 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 #  This is a Rails API stack that launches on a background

--- a/test/servers/sidekiq.rb
+++ b/test/servers/sidekiq.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # We configure and launch Sidekiq in a background

--- a/test/servers/sidekiq_initializer.rb
+++ b/test/servers/sidekiq_initializer.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 # This file is used to initialize the background Sidekiq

--- a/test/support/auto_tracing_test.rb
+++ b/test/support/auto_tracing_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/avw_handling_test.rb
+++ b/test/support/avw_handling_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/backcompat_test.rb
+++ b/test/support/backcompat_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/config_test.rb
+++ b/test/support/config_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/dnt_test.rb
+++ b/test/support/dnt_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/init_report_test.rb
+++ b/test/support/init_report_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/liboboe_settings_test.rb
+++ b/test/support/liboboe_settings_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'set'

--- a/test/support/noop_test.rb
+++ b/test/support/noop_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/sql_sanitize_test.rb
+++ b/test/support/sql_sanitize_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/tracing_mode_test.rb
+++ b/test/support/tracing_mode_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/tvalias_test.rb
+++ b/test/support/tvalias_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/test/support/xtrace_test.rb
+++ b/test/support/xtrace_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 AppNeta, Inc.
+# Copyright (c) 2016 SolarWinds, LLC.
 # All rights reserved.
 
 require 'minitest_helper'

--- a/traceview.gemspec
+++ b/traceview.gemspec
@@ -6,12 +6,12 @@ Gem::Specification.new do |s|
   s.version = TraceView::Version::STRING
   s.date = Time.now.strftime('%Y-%m-%d')
 
-  s.license = "AppNeta Open License, Version 1.0"
+  s.license = "Librato Open License, Version 1.0"
 
   s.authors = ["Peter Giacomo Lombardo", "Spiros Eliopoulos"]
-  s.email = %q{traceviewsupport@appneta.com}
-  s.homepage = %q{http://www.appneta.com/products/traceview/}
-  s.summary = %q{AppNeta TraceView performance instrumentation gem for Ruby}
+  s.email = %q{traceviewsupport@solarwinds.com}
+  s.homepage = %q{https://traceview.solarwinds.com/}
+  s.summary = %q{TraceView performance instrumentation gem for Ruby}
   s.description = %q{The TraceView gem provides performance instrumentation for MRI Ruby, JRuby and related frameworks.}
 
   s.extra_rdoc_files = ["LICENSE"]
@@ -45,4 +45,3 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.8.6'
 end
-


### PR DESCRIPTION
Updated License, copyright, links to docs, support email and portal, and links to the github repo.

Left references to AppNeta in the CHANGELOG history for posterity.